### PR TITLE
add intersphinx mapping to config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,8 +43,23 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.githubpages',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax'
     ]
+
+intersphinx_mapping = {
+    'fates-users-guide': ('https://fates-users-guide.readthedocs.io/', None),
+}
+
+intersphinx_disabled_domains = ['std']
+
+# RTD recommends adding the following config value.
+# Sphinx defaults to automatically resolve *unresolved* labels using all your Intersphinx mappings.
+# This behavior has unintended side-effects, namely that documentations local references can
+# suddenly resolve to an external location.
+# See also:
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_disabled_reftypes
+intersphinx_disabled_reftypes = ["*"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['sphinx_templates']


### PR DESCRIPTION
This will allow the user's guide to reference sections in the tech-doc and vice versa